### PR TITLE
Adds a "Hide Member Items" checkbox to the ABC Alchemy Panel

### DIFF
--- a/src/main/java/com/vartan/abc/AbcAlchPanel.java
+++ b/src/main/java/com/vartan/abc/AbcAlchPanel.java
@@ -3,6 +3,7 @@ package com.vartan.abc;
 import com.vartan.abc.model.AlchItem;
 import com.vartan.abc.util.IntegerUtil;
 import net.runelite.api.Client;
+import net.runelite.api.ItemComposition;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -15,6 +16,8 @@ import javax.swing.event.DocumentListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.awt.image.BufferedImage;
 
 public class AbcAlchPanel extends PluginPanel {
@@ -25,6 +28,7 @@ public class AbcAlchPanel extends PluginPanel {
     private final ItemManager itemManager;
     JTextField minimumTradeLimitField;
     JTextField maxPriceField;
+    JToggleButton filterMemberItems;
     JComboBox priceSourceBox;
     AbcAlchPlugin plugin;
     JPanel alchList;
@@ -56,6 +60,18 @@ public class AbcAlchPanel extends PluginPanel {
             }
         };
 
+        ItemListener itemListener = new ItemListener() {
+            void update(ItemEvent e) {
+                searchButton.setText("Search");
+                searchButton.revalidate();
+            }
+
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                update(e);
+            }
+        };
+
         setBorder(new EmptyBorder(6, 6, 6, 6));
         setBackground(ColorScheme.DARK_GRAY_COLOR);
         setLayout(new BorderLayout());
@@ -75,6 +91,13 @@ public class AbcAlchPanel extends PluginPanel {
         minimumTradeLimitRow.setToolTipText("Filters out items with a trade limit less than the given value. " + "0 to disable.");
         layoutPanel.add(minimumTradeLimitRow);
         minimumTradeLimitField.getDocument().addDocumentListener(onInputChanged);
+
+        filterMemberItems = new JToggleButton();
+        JPanel filterMemberItemsRow = createLabeledRow("Hide Member Items:", filterMemberItems);
+        filterMemberItemsRow.setToolTipText("If you're like to hide member items from the list.");
+        layoutPanel.add(filterMemberItemsRow);
+        filterMemberItems.addItemListener(itemListener);
+
 
         priceSourceBox = new JComboBox(PRICE_SOURCE_OPTIONS);
         priceSourceBox.setSelectedIndex(0);
@@ -136,6 +159,10 @@ public class AbcAlchPanel extends PluginPanel {
             int geLimit = item.getGeLimit();
             int minimumTradeLimit = readNumericTextField(this.minimumTradeLimitField);
             int maxPrice = readNumericTextField(this.maxPriceField);
+            boolean memberItem = item.getIsMember();
+            if (this.filterMemberItems.isSelected() && memberItem) {
+                continue;
+            }
             boolean filterGeLimit = geLimit != 0 && minimumTradeLimit != 0 && geLimit < minimumTradeLimit;
             boolean filterPrice = maxPrice != 0 && item.getGePrice() >= maxPrice;
             if (filterGeLimit || filterPrice) {

--- a/src/main/java/com/vartan/abc/AbcAlchPanel.java
+++ b/src/main/java/com/vartan/abc/AbcAlchPanel.java
@@ -102,8 +102,7 @@ public class AbcAlchPanel extends PluginPanel {
         });
         layoutPanel.add(createLabeledRow("Price Source:", priceSourceBox));
 
-        includeMemberItems = new JCheckBox();
-        includeMemberItems.doClick();
+        includeMemberItems = new JCheckBox("",true);
         JPanel includeMemberItemsRow = createLabeledRow("Members' Items:", includeMemberItems);
         includeMemberItemsRow.setToolTipText("Include items that are members only.");
         layoutPanel.add(includeMemberItemsRow);

--- a/src/main/java/com/vartan/abc/AbcAlchPanel.java
+++ b/src/main/java/com/vartan/abc/AbcAlchPanel.java
@@ -91,13 +91,6 @@ public class AbcAlchPanel extends PluginPanel {
         layoutPanel.add(minimumTradeLimitRow);
         minimumTradeLimitField.getDocument().addDocumentListener(onInputChanged);
 
-        filterMemberItems = new JToggleButton();
-        JPanel filterMemberItemsRow = createLabeledRow("Hide Member Items:", filterMemberItems);
-        filterMemberItemsRow.setToolTipText("If you're like to hide member items from the list.");
-        layoutPanel.add(filterMemberItemsRow);
-        filterMemberItems.addItemListener(itemListener);
-
-
         priceSourceBox = new JComboBox(PRICE_SOURCE_OPTIONS);
         priceSourceBox.setSelectedIndex(0);
         priceSourceBox.addActionListener(new ActionListener() {
@@ -108,6 +101,12 @@ public class AbcAlchPanel extends PluginPanel {
             }
         });
         layoutPanel.add(createLabeledRow("Price Source:", priceSourceBox));
+
+        filterMemberItems = new JCheckBox();
+        JPanel filterMemberItemsRow = createLabeledRow("Hide Member Items:", filterMemberItems);
+        filterMemberItemsRow.setToolTipText("If you're like to hide member items from the list.");
+        layoutPanel.add(filterMemberItemsRow);
+        filterMemberItems.addItemListener(itemListener);
 
         searchButton.addActionListener(new ActionListener() {
             @Override

--- a/src/main/java/com/vartan/abc/AbcAlchPanel.java
+++ b/src/main/java/com/vartan/abc/AbcAlchPanel.java
@@ -3,7 +3,6 @@ package com.vartan.abc;
 import com.vartan.abc.model.AlchItem;
 import com.vartan.abc.util.IntegerUtil;
 import net.runelite.api.Client;
-import net.runelite.api.ItemComposition;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;

--- a/src/main/java/com/vartan/abc/AbcAlchPanel.java
+++ b/src/main/java/com/vartan/abc/AbcAlchPanel.java
@@ -15,6 +15,8 @@ import javax.swing.event.DocumentListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.awt.image.BufferedImage;
 
 public class AbcAlchPanel extends PluginPanel {
@@ -25,6 +27,7 @@ public class AbcAlchPanel extends PluginPanel {
     private final ItemManager itemManager;
     JTextField minimumTradeLimitField;
     JTextField maxPriceField;
+    JToggleButton filterMemberItems;
     JComboBox priceSourceBox;
     AbcAlchPlugin plugin;
     JPanel alchList;
@@ -56,6 +59,18 @@ public class AbcAlchPanel extends PluginPanel {
             }
         };
 
+        ItemListener itemListener = new ItemListener() {
+            void update(ItemEvent e) {
+                searchButton.setText("Search");
+                searchButton.revalidate();
+            }
+
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                update(e);
+            }
+        };
+
         setBorder(new EmptyBorder(6, 6, 6, 6));
         setBackground(ColorScheme.DARK_GRAY_COLOR);
         setLayout(new BorderLayout());
@@ -75,6 +90,13 @@ public class AbcAlchPanel extends PluginPanel {
         minimumTradeLimitRow.setToolTipText("Filters out items with a trade limit less than the given value. " + "0 to disable.");
         layoutPanel.add(minimumTradeLimitRow);
         minimumTradeLimitField.getDocument().addDocumentListener(onInputChanged);
+
+        filterMemberItems = new JToggleButton();
+        JPanel filterMemberItemsRow = createLabeledRow("Hide Member Items:", filterMemberItems);
+        filterMemberItemsRow.setToolTipText("If you're like to hide member items from the list.");
+        layoutPanel.add(filterMemberItemsRow);
+        filterMemberItems.addItemListener(itemListener);
+
 
         priceSourceBox = new JComboBox(PRICE_SOURCE_OPTIONS);
         priceSourceBox.setSelectedIndex(0);
@@ -136,6 +158,10 @@ public class AbcAlchPanel extends PluginPanel {
             int geLimit = item.getGeLimit();
             int minimumTradeLimit = readNumericTextField(this.minimumTradeLimitField);
             int maxPrice = readNumericTextField(this.maxPriceField);
+            boolean memberItem = item.getIsMember();
+            if (this.filterMemberItems.isSelected() && memberItem) {
+                continue;
+            }
             boolean filterGeLimit = geLimit != 0 && minimumTradeLimit != 0 && geLimit < minimumTradeLimit;
             boolean filterPrice = maxPrice != 0 && item.getGePrice() >= maxPrice;
             if (filterGeLimit || filterPrice) {

--- a/src/main/java/com/vartan/abc/AbcAlchPanel.java
+++ b/src/main/java/com/vartan/abc/AbcAlchPanel.java
@@ -27,7 +27,7 @@ public class AbcAlchPanel extends PluginPanel {
     private final ItemManager itemManager;
     JTextField minimumTradeLimitField;
     JTextField maxPriceField;
-    JToggleButton filterMemberItems;
+    JToggleButton includeMemberItems;
     JComboBox priceSourceBox;
     AbcAlchPlugin plugin;
     JPanel alchList;
@@ -102,11 +102,12 @@ public class AbcAlchPanel extends PluginPanel {
         });
         layoutPanel.add(createLabeledRow("Price Source:", priceSourceBox));
 
-        filterMemberItems = new JCheckBox();
-        JPanel filterMemberItemsRow = createLabeledRow("Hide Members' Item:", filterMemberItems);
-        filterMemberItemsRow.setToolTipText("If you'd like to hide members' item from the list.");
-        layoutPanel.add(filterMemberItemsRow);
-        filterMemberItems.addItemListener(itemListener);
+        includeMemberItems = new JCheckBox();
+        includeMemberItems.doClick();
+        JPanel includeMemberItemsRow = createLabeledRow("Members' Items:", includeMemberItems);
+        includeMemberItemsRow.setToolTipText("Include items that are members only.");
+        layoutPanel.add(includeMemberItemsRow);
+        includeMemberItems.addItemListener(itemListener);
 
         searchButton.addActionListener(new ActionListener() {
             @Override
@@ -158,7 +159,7 @@ public class AbcAlchPanel extends PluginPanel {
             int minimumTradeLimit = readNumericTextField(this.minimumTradeLimitField);
             int maxPrice = readNumericTextField(this.maxPriceField);
             boolean isMembers = item.getIsMembers();
-            if (this.filterMemberItems.isSelected() && isMembers) {
+            if (!this.includeMemberItems.isSelected() && isMembers) {
                 continue;
             }
             boolean filterGeLimit = geLimit != 0 && minimumTradeLimit != 0 && geLimit < minimumTradeLimit;

--- a/src/main/java/com/vartan/abc/AbcAlchPanel.java
+++ b/src/main/java/com/vartan/abc/AbcAlchPanel.java
@@ -103,8 +103,8 @@ public class AbcAlchPanel extends PluginPanel {
         layoutPanel.add(createLabeledRow("Price Source:", priceSourceBox));
 
         filterMemberItems = new JCheckBox();
-        JPanel filterMemberItemsRow = createLabeledRow("Hide Member Items:", filterMemberItems);
-        filterMemberItemsRow.setToolTipText("If you're like to hide member items from the list.");
+        JPanel filterMemberItemsRow = createLabeledRow("Hide Members' Item:", filterMemberItems);
+        filterMemberItemsRow.setToolTipText("If you'd like to hide members' item from the list.");
         layoutPanel.add(filterMemberItemsRow);
         filterMemberItems.addItemListener(itemListener);
 
@@ -157,8 +157,8 @@ public class AbcAlchPanel extends PluginPanel {
             int geLimit = item.getGeLimit();
             int minimumTradeLimit = readNumericTextField(this.minimumTradeLimitField);
             int maxPrice = readNumericTextField(this.maxPriceField);
-            boolean memberItem = item.getIsMember();
-            if (this.filterMemberItems.isSelected() && memberItem) {
+            boolean isMembers = item.getIsMembers();
+            if (this.filterMemberItems.isSelected() && isMembers) {
                 continue;
             }
             boolean filterGeLimit = geLimit != 0 && minimumTradeLimit != 0 && geLimit < minimumTradeLimit;

--- a/src/main/java/com/vartan/abc/AbcAlchPlugin.java
+++ b/src/main/java/com/vartan/abc/AbcAlchPlugin.java
@@ -134,13 +134,14 @@ public class AbcAlchPlugin extends Plugin {
             int highAlchPrice = itemComposition.getHaPrice();
             int highAlchProfit = highAlchPrice - gePrice - natureRunePrice;
             int geLimit = itemStats.getGeLimit();
+            boolean isMember = itemComposition.isMembers();
             if (highAlchProfit < 0) {
                 // Avoid creating entries for items that will never be displayed.
                 continue;
             }
 
             BufferedImage image = itemManager.getImage(itemId, geLimit, false);
-            tempAlchItems.add(new AlchItem(name, gePrice, highAlchPrice, highAlchProfit, geLimit, image));
+            tempAlchItems.add(new AlchItem(name, gePrice, highAlchPrice, highAlchProfit, geLimit, isMember, image));
         }
         // Sort by high alchemy profit,
         this.alchItems = Ordering.from(Comparator.comparing(AlchItem::getHighAlchProfit)).reverse().immutableSortedCopy(tempAlchItems);

--- a/src/main/java/com/vartan/abc/AbcAlchPlugin.java
+++ b/src/main/java/com/vartan/abc/AbcAlchPlugin.java
@@ -134,14 +134,14 @@ public class AbcAlchPlugin extends Plugin {
             int highAlchPrice = itemComposition.getHaPrice();
             int highAlchProfit = highAlchPrice - gePrice - natureRunePrice;
             int geLimit = itemStats.getGeLimit();
-            boolean isMember = itemComposition.isMembers();
+            boolean isMembers = itemComposition.isMembers();
             if (highAlchProfit < 0) {
                 // Avoid creating entries for items that will never be displayed.
                 continue;
             }
 
             BufferedImage image = itemManager.getImage(itemId, geLimit, false);
-            tempAlchItems.add(new AlchItem(name, gePrice, highAlchPrice, highAlchProfit, geLimit, isMember, image));
+            tempAlchItems.add(new AlchItem(name, gePrice, highAlchPrice, highAlchProfit, geLimit, isMembers, image));
         }
         // Sort by high alchemy profit,
         this.alchItems = Ordering.from(Comparator.comparing(AlchItem::getHighAlchProfit)).reverse().immutableSortedCopy(tempAlchItems);

--- a/src/main/java/com/vartan/abc/model/AlchItem.java
+++ b/src/main/java/com/vartan/abc/model/AlchItem.java
@@ -10,16 +10,18 @@ public class AlchItem {
     private final String name;
     private final int gePrice;
     private final int geLimit;
+    private final boolean isMember;
     private final BufferedImage image;
     private final int highAlchPrice;
     private final int highAlchProfit;
 
-    public AlchItem(String name, int gePrice, int highAlchPrice, int highAlchProfit, int geLimit, BufferedImage image) {
+    public AlchItem(String name, int gePrice, int highAlchPrice, int highAlchProfit, int geLimit, boolean isMember, BufferedImage image) {
         this.name = name;
         this.gePrice = gePrice;
         this.highAlchPrice = highAlchPrice;
         this.highAlchProfit = highAlchProfit;
         this.geLimit = geLimit;
+        this.isMember = isMember;
         this.image = createAlchImage(image, geLimit);
     }
 
@@ -42,6 +44,10 @@ public class AlchItem {
 
     public int getGeLimit() {
         return geLimit;
+    }
+
+    public boolean getIsMember() {
+        return isMember;
     }
 
     public int getHighAlchProfit() {

--- a/src/main/java/com/vartan/abc/model/AlchItem.java
+++ b/src/main/java/com/vartan/abc/model/AlchItem.java
@@ -10,18 +10,18 @@ public class AlchItem {
     private final String name;
     private final int gePrice;
     private final int geLimit;
-    private final boolean isMember;
+    private final boolean isMembers;
     private final BufferedImage image;
     private final int highAlchPrice;
     private final int highAlchProfit;
 
-    public AlchItem(String name, int gePrice, int highAlchPrice, int highAlchProfit, int geLimit, boolean isMember, BufferedImage image) {
+    public AlchItem(String name, int gePrice, int highAlchPrice, int highAlchProfit, int geLimit, boolean isMembers, BufferedImage image) {
         this.name = name;
         this.gePrice = gePrice;
         this.highAlchPrice = highAlchPrice;
         this.highAlchProfit = highAlchProfit;
         this.geLimit = geLimit;
-        this.isMember = isMember;
+        this.isMembers = isMembers;
         this.image = createAlchImage(image, geLimit);
     }
 
@@ -46,8 +46,8 @@ public class AlchItem {
         return geLimit;
     }
 
-    public boolean getIsMember() {
-        return isMember;
+    public boolean getIsMembers() {
+        return isMembers;
     }
 
     public int getHighAlchProfit() {


### PR DESCRIPTION
Adding a "Hide Member Items" checkbox



Adds a "Hide Member Items" checkbox to the Panel, when refreshed/searched again the list updates to hide items that are tags as "isMember".
(Info taken from https://static.runelite.net/runelite-api/apidocs/net/runelite/api/ItemComposition.html#isMembers() )

Preview images:
![image](https://github.com/user-attachments/assets/55324bd6-e713-4693-a156-85e4750f7dd6)
![image](https://github.com/user-attachments/assets/bc4cdef9-865a-4d7f-ad77-51ad1745001a)
