### PR TITLE
Fix Low and High Alchemy widget child IDs broken by the Minigame teleport addition

### DIFF
--- a/src/main/java/com/vartan/abc/model/Spell.java
+++ b/src/main/java/com/vartan/abc/model/Spell.java
@@ -1,8 +1,8 @@
 package com.vartan.abc.model;
 
 public enum Spell {
-    LOW_LEVEL_ALCHEMY(31, 3, 22),
-    HIGH_LEVEL_ALCHEMY(65, 5, 45);
+    LOW_LEVEL_ALCHEMY(31, 3, 25),
+    HIGH_LEVEL_ALCHEMY(65, 5, 48);
 
     public final int xpGained;
     /**

--- a/src/main/java/com/vartan/abc/model/Spell.java
+++ b/src/main/java/com/vartan/abc/model/Spell.java
@@ -1,8 +1,8 @@
 package com.vartan.abc.model;
 
 public enum Spell {
-    LOW_LEVEL_ALCHEMY(31, 3, 21),
-    HIGH_LEVEL_ALCHEMY(65, 5, 44);
+    LOW_LEVEL_ALCHEMY(31, 3, 22),
+    HIGH_LEVEL_ALCHEMY(65, 5, 45);
 
     public final int xpGained;
     /**


### PR DESCRIPTION
The Minigame teleport spell addition nudged most spell IDs by one. The Low and High Alchemy widget child IDs are now 22 and 45 respectively.

Fixes #12.